### PR TITLE
Added util.h library to solve 1.5.x issue

### DIFF
--- a/icmp_ping/util.h
+++ b/icmp_ping/util.h
@@ -1,0 +1,14 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#define htons(x) ( ((x)<< 8 & 0xFF00) | \
+                   ((x)>> 8 & 0x00FF) )
+#define ntohs(x) htons(x)
+
+#define htonl(x) ( ((x)<<24 & 0xFF000000UL) | \
+                   ((x)<< 8 & 0x00FF0000UL) | \
+                   ((x)>> 8 & 0x0000FF00UL) | \
+                   ((x)>>24 & 0x000000FFUL) )
+#define ntohl(x) htonl(x)
+
+#endif


### PR DESCRIPTION
in version 1.5.x the `util` library has been moved to `Ethernet/.../utility/util.h`
So its a better idea to keep a version of this small library along with the ICMPPing library to provide compatiblity with each version of IDE.

Error given otherwise in IDE 1.5.x
```
/Applications/Arduino1.5.0.app/Contents/Java/libraries/icmp_ping/ICMPPing.cpp:11:18: fatal error: util.h: No such file or directory
 #include <util.h>
                  ^
compilation terminated.
Error compiling.
```