### PR TITLE
One major new feature (asynchronous ICMP) and a few minor mods

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,1 +1,2 @@
 Blake Foster
+Pat Deegan

--- a/icmp_ping/ICMPPing.h
+++ b/icmp_ping/ICMPPing.h
@@ -18,7 +18,19 @@
 #define TIME_EXCEEDED 11
 #define PING_TIMEOUT 1000
 
-typedef unsigned long time_t;
+
+// ICMPPING_ASYNCH_ENABLE -- define this to enable asynch operations
+// #define ICMPPING_ASYNCH_ENABLE
+
+// ICMPPING_INSERT_YIELDS -- some platforms, such as ESP8266, like
+// (read: need) to do background work so control must be yielded
+// back to the main system periodically when you are doing something
+// that takes a good while.
+// Define (uncomment the following line) on these platforms, which
+// will call a short delay() at critical junctures.
+// #define ICMPPING_INSERT_YIELDS
+
+typedef unsigned long icmp_time_t;
 
 class ICMPHeader;
 class ICMPPing;
@@ -33,8 +45,9 @@ typedef enum Status
     SUCCESS = 0,
     SEND_TIMEOUT = 1, // Timed out sending the request
     NO_RESPONSE = 2, // Died waiting for a response
-    BAD_RESPONSE = 3 // we got back the wrong type
-};
+    BAD_RESPONSE = 3, // we got back the wrong type
+    ASYNC_SENT = 4
+} Status;
 
 
 struct ICMPHeader
@@ -77,7 +90,7 @@ struct ICMPEcho
     ICMPHeader icmpHeader;
     uint16_t id;
     uint16_t seq;
-    time_t time;
+    icmp_time_t time;
     uint8_t payload [REQ_DATASIZE];
 
     /*
@@ -124,6 +137,22 @@ public:
     */
     ICMPPing(SOCKET s, uint8_t id);
 
+
+    /*
+     Control the ping timeout (ms).  Defaults to PING_TIMEOUT (1000ms) but can
+     be set using setTimeout(MS).
+     @param timeout_ms: Timeout for ping replies, in milliseconds.
+     @note: this value is static -- i.e. system-wide for all ICMPPing objects.
+     */
+    static void setTimeout(uint16_t setTo) { ping_timeout = setTo;}
+
+    /*
+     Fetch the current setting for ping timeouts (in ms).
+     @return: timeout for all ICMPPing requests, in milliseconds.
+     */
+    static uint16_t timeout() { return ping_timeout;}
+
+
     /*
     Pings the given IP address.
     @param addr: IP address to ping, as an array of four octets.
@@ -146,14 +175,124 @@ public:
     */
     void operator()(const IPAddress& addr, int nRetries, ICMPEchoReply& result);
 
+
+
+    /*
+     Use setPayload to set custom data for all ICMP packets
+     by passing it an array of [REQ_DATASIZE].  E.g.
+       uint8_t myPayload[REQ_DATASIZE] = { ... whatever ...};
+       ICMPPing ping(pingSocket, (uint16_t)random(0, 255));
+       ping.setPayload(myPayload);
+       // ... as usual ...
+
+     @param payload: pointer to start of REQ_DATASIZE array of bytes to use as payload
+
+    */
+    void setPayload(uint8_t * payload);
+
+#ifdef ICMPPING_ASYNCH_ENABLE
+    /*
+     Asynchronous ping methods -- only enabled if ICMPPING_ASYNCH_ENABLE is defined, above.
+
+     These methods are used to start a ping request, go do something else, and 
+     come back later to check if the results are in. A complete example is in the 
+     examples directory but the gist of it is E.g.
+
+
+       // say we're in some function, to simplify things...
+       IPAddress pingAddr(74,125,26,147); // ip address to ping
+
+       ICMPPing ping(0, (uint16_t)random(0, 255));
+       ICMPEchoReply theResult;
+
+       if (! asyncStart(pingAddr, 3, theResult))
+       {
+       	   // well, this didn't start off on the right foot
+       	   Serial.print("Echo request send failed; ");
+       	   Serial.println((int)theResult.status);
+
+       	   //
+       	   return; // forget about this
+       }
+
+       // ok, ping has started...
+       while (! ping.asyncComplete(theResult)) {
+
+       	   // whatever needs handling while we wait on results
+       	   doSomeStuff();
+       	   doSomeOtherStuff();
+       	   delay(30);
+
+       }
+
+       // we get here means we either got a response, or timed out...
+       if (theResult.status == SUCCESS)
+       {
+       	   // yay... do something.
+       } else {
+       	   // boooo... do something else.
+       }
+
+       return;
+
+
+     */ 
+
+
+    /*
+     asyncStart -- begins a new ping request, asynchronously.  Parameters are the 
+     same as for regular ping, but the method returns false on error.
+
+     @param addr: IP address to ping, as an array of four octets.
+     @param nRetries: Number of times to rety before giving up.
+     @param result: ICMPEchoReply that will hold a status == ASYNC_SENT on success.
+     @return: true on async request sent, false otherwise.
+     @author: Pat Deegan, http://psychogenic.com
+    */
+    bool asyncStart(const IPAddress& addr, int nRetries, ICMPEchoReply& result);
+
+
+    /*
+     asyncComplete --  check if the asynchronous ping is done.
+     This can be either because of a successful outcome (reply received)
+     or because of an error/timeout.
+
+     @param result: ICMPEchoReply that will hold the result.
+     @return: true if the result ICMPEchoReply contains the status/other data,
+              false if we're still waiting for it to complete.
+     @author: Pat Deegan, http://psychogenic.com
+    */
+    bool asyncComplete(ICMPEchoReply& result);
+#endif
+
 private:
+
+    // holds the timeout, in ms, for all objects of this class.
+    static uint16_t ping_timeout;
+
+    void openSocket();
 
     Status sendEchoRequest(const IPAddress& addr, const ICMPEcho& echoReq);
     void receiveEchoReply(const ICMPEcho& echoReq, const IPAddress& addr, ICMPEchoReply& echoReply);
 
+
+
+#ifdef ICMPPING_ASYNCH_ENABLE
+    // extra internal state/methods used when asynchronous pings
+    // are enabled.
+    bool asyncSend(ICMPEchoReply& result);
+    uint8_t _curSeq;
+    uint8_t _numRetries;
+    icmp_time_t _asyncstart;
+    Status _asyncstatus;
+    IPAddress	_addr;
+#endif
     uint8_t _id;
     uint8_t _nextSeq;
     SOCKET _socket;
+    uint8_t _attempt;
+
+    uint8_t _payload[REQ_DATASIZE];
 };
 
 #pragma pack(1)

--- a/icmp_ping/examples/PingAsync/PingAsync.ino
+++ b/icmp_ping/examples/PingAsync/PingAsync.ino
@@ -1,0 +1,190 @@
+/*
+ * PingAsync.cpp
+ * This example uses the asynchronous methods of ICMPPing to send a ping,
+ * do "other stuff" and check back for results periodically.
+ *
+ *
+ * See the basic "Ping" example, on which this is based, for simpler
+ * (but synchronous--meaning code will be frozen while awaiting responses)
+ * usage.
+ *
+ * Setup: Configure the various defines in the Configuration section, below,
+ * to select whether to use DHCP or a static IP and to choose the remote host
+ * to ping.
+ *
+ * Circuit:
+ * Ethernet shield attached to pins 10, 11, 12, 13
+ * OR other wiznet 5100-based board (tested on the WIZ811MJ, for example),
+ * suitably connected.
+ *
+ *  Created on: Dec 12, 2015
+ *      Author: Pat Deegan
+ *      Part of the ICMPPing Project
+ *      Copyright (C) 2015 Pat Deegan, http://psychogenic.com
+ * 
+ * This file is free software; you can redistribute it and/or modify it under the terms 
+ * of either the GNU General Public License version 2 or the GNU Lesser General Public 
+ * License version 2.1, both as published by the Free Software Foundation.
+ */
+#include <SPI.h>
+#include <Ethernet.h>
+#include <ICMPPing.h>
+
+
+/* ************ Configuration ************** */
+
+
+// NOTE: Use *COMMAS* (,) between IP values, as we're
+// using these to init the constructors
+
+// PING_REMOTE_IP -- remote host to ping (see NOTE above)
+// so, e.g., 162.220.162.142 becomes 162, 220, 162, 142
+#define PING_REMOTE_IP      162, 220, 162, 142
+
+
+// TEST_USING_STATIC_IP -- (see NOTE above)
+// leave undefined (commented out)
+// to use DHCP instead.
+// #define TEST_USING_STATIC_IP  192, 168, 2, 177
+
+
+
+
+// PING_REQUEST_TIMEOUT_MS -- timeout in ms.  between 1 and 65000 or so
+// save values: 1000 to 5000, say.
+#define PING_REQUEST_TIMEOUT_MS     2500
+
+#define LOCAL_MAC_ADDRESS     0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+
+#ifndef ICMPPING_ASYNCH_ENABLE
+#error "Asynchronous functions only available if ICMPPING_ASYNCH_ENABLE is defined -- see ICMPPing.h"
+#endif
+
+
+
+byte mac[] = {LOCAL_MAC_ADDRESS}; // max address for ethernet shield
+
+#ifdef TEST_USING_STATIC_IP
+byte ip[] = {TEST_USING_STATIC_IP}; // ip address for ethernet shield
+#endif
+
+IPAddress pingAddr(PING_REMOTE_IP); // ip address to ping
+
+SOCKET pingSocket = 0;
+
+char buffer [256];
+ICMPPing ping(pingSocket, 1);
+
+void dieWithMessage(const char * msg)
+{
+
+  for (;;)
+  {
+    Serial.println(msg);
+    delay(500);
+  }
+}
+
+void setup()
+{
+  // start Ethernet
+  Serial.begin(115200);
+
+  Serial.println("PingAsync booted...");
+  Serial.print("Configuring ethernet with ");
+
+#ifdef TEST_USING_STATIC_IP
+
+  Serial.println("static ip");
+  Ethernet.begin(mac, ip);
+#else
+
+  Serial.print("DHCP...");
+  if (! Ethernet.begin(mac) )
+  {
+
+    Serial.println("FAILURE");
+    dieWithMessage("Couldn't init ethernet using DHCP?!");
+  }
+
+  Serial.println("Success!");
+#endif
+
+  // increase the default time-out, if needed, assuming a bad
+  // connection or whatever.
+  ICMPPing::setTimeout(PING_REQUEST_TIMEOUT_MS);
+
+}
+
+
+// lastPingSucceeded -- just a flag so we don't drown in
+// output when things are going wrong...
+bool lastPingSucceeded = false;
+
+// someCriticalStuffThatCantWait is just a toy function
+// to represent the *reason* you want to use asynchronous
+// calls rather than wait around for pings to come home.
+// Here, we just print out some chars...
+void someCriticalStuffThatCantWait()
+{
+  for (int i = 0; i < 10; i++)
+  {
+    if (lastPingSucceeded) {
+      Serial.print('.');
+    }
+  }
+  Serial.print('_');
+}
+
+void loop()
+{
+
+  lastPingSucceeded = false;
+  ICMPEchoReply echoResult;  // we'll get the status here
+  Serial.println("Starting async ping.");
+
+  // asynchStart will return false if we couldn't
+  // even send a ping, though you could also check the
+  // echoResult.status with should ==
+  if (! ping.asyncStart(pingAddr, 3, echoResult))
+  {
+    Serial.print("Couldn't even send our ping request?? Status: ");
+    Serial.println((int)echoResult.status);
+    delay(500);
+    return;
+
+  }
+
+  // ok the ping started out well...
+  Serial.println("Ping sent ");
+  while (! ping.asyncComplete(echoResult))
+  {
+    // we have critical stuff we wish to handle
+    // while we wait for ping to come back
+    someCriticalStuffThatCantWait();
+  }
+
+  // async is done!  let's see how it worked out...
+  if (echoResult.status != SUCCESS)
+  {
+    // failure... but whyyyy?
+    sprintf(buffer, "Echo request failed; %d", echoResult.status);
+  } else {
+    // huzzah
+    lastPingSucceeded = true;
+    sprintf(buffer,
+            "Reply[%d] from: %d.%d.%d.%d: bytes=%d time=%ldms TTL=%d",
+            echoResult.data.seq,
+            echoResult.addr[0],
+            echoResult.addr[1],
+            echoResult.addr[2],
+            echoResult.addr[3],
+            REQ_DATASIZE,
+            millis() - echoResult.data.time,
+            echoResult.ttl);
+  }
+
+  Serial.println(buffer);
+  delay(500);
+}
+


### PR DESCRIPTION
One major new feature (asynchronous ICMP requests, and a little bit of re-working to support it) along with three minor modifications.

The async ICMP is used when you have time critical code to execute and/or don't like the idea of waiting around on network events.  You first call asyncStart() to send an ICMP packet, then periodically poll to see whether results are in using asyncComplete().  The API is documented and an example is available in the examples/ directory.

Minor mods are:
- a configurable (system-wide) timeout for pings;
- a configurable ICMP payload per request; and
- a new (optional) define that enables system yields at critical points (important for both synchronous and async pings on systems like ESP8266).

The patch applied by this push leaves things mostly unchanged, as neither ICMPPING_ASYNCH_ENABLE nor ICMPPING_INSERT_YIELDS are defined.
To enable these features, edit  icmp_ping/ICMPPing.h and uncomment the defines as needed.

I've run both examples, Ping and AsyncPing, on an ESP8266 with async enabled and yields on, and also run the Ping example with those functions completly disabled.

Hope this is useful to others! Regards,
Pat Deegan, http://psychogenic.com
